### PR TITLE
Handle different cases for messageID stream

### DIFF
--- a/GETTING_STARTED_READ_FROM_STREAM_WRITE_TO_COLLECTION.md
+++ b/GETTING_STARTED_READ_FROM_STREAM_WRITE_TO_COLLECTION.md
@@ -23,6 +23,7 @@ val sourceOptions = Map(
   "tenant" -> tenant,
   "replication" -> replication,
   "stream" -> sourceStream,
+  "isCollectionStream" -> "false", // Indicates if this is a collection stream (true) or not (false), represented as a string value
   "subscriptionName" -> sourceSubscription
 )
 ```

--- a/GETTING_STARTED_WITH_STREAM_DATA_CONNECTOR.md
+++ b/GETTING_STARTED_WITH_STREAM_DATA_CONNECTOR.md
@@ -23,6 +23,7 @@ val sourceOptions = Map(
   "tenant" -> "<TENANT>",
   "replication" -> "<REPLICATION>",
   "stream" -> "<SOURCE_STREAM>",
+  "isCollectionStream" -> "<true or false>", // Indicates if this is a collection stream (true) or not (false), represented as a string value
   "subscriptionName" -> "<SOURCE_SUBSCRIPTION>"
 )
 ```

--- a/app/src/main/scala/com/macrometa/spark/stream/read/microbatch/MacrometaMicroBatchStream.scala
+++ b/app/src/main/scala/com/macrometa/spark/stream/read/microbatch/MacrometaMicroBatchStream.scala
@@ -42,8 +42,20 @@ class MacrometaMicroBatchStream(
 
   private def toMessageIdImpl(messageId: Option[MessageId]): MessageIdImpl = {
     val messageIdString = messageId.toString
-    val Array(ledgerId, entryId, partitionIndex) =
-      messageIdString.stripPrefix("Some(").stripSuffix(")").split(":").map(_.toLong)
+    val strippedMessageIdString = messageIdString.stripPrefix("Some(").stripSuffix(")")
+    val components = strippedMessageIdString.split(":").map(_.toLong)
+
+    val (ledgerId, entryId, partitionIndex) = components match {
+      case Array(ledger, entry, partition, _*) =>
+        (ledger, entry, partition)
+      case Array(ledger, entry) =>
+        (ledger, entry, 0L)
+      case Array(ledger) =>
+        (ledger, 0L, 0L)
+      case _ =>
+        throw new RuntimeException(s"Invalid messageId received: $messageIdString")
+    }
+
     new MessageIdImpl(ledgerId, entryId, partitionIndex.toInt)
   }
 

--- a/app/src/main/scala/com/macrometa/spark/stream/read/microbatch/MacrometaMicroBatchStream.scala
+++ b/app/src/main/scala/com/macrometa/spark/stream/read/microbatch/MacrometaMicroBatchStream.scala
@@ -50,8 +50,6 @@ class MacrometaMicroBatchStream(
         (ledger, entry, partition)
       case Array(ledger, entry) =>
         (ledger, entry, 0L)
-      case Array(ledger) =>
-        (ledger, 0L, 0L)
       case _ =>
         throw new RuntimeException(s"Invalid messageId received: $messageIdString")
     }


### PR DESCRIPTION
We seem to be receiving messageId sometimes with 4 splits indicating a BatchIndex is also present in messageId and sometimes no BatchIndex so just handling these cases such that we don't throw an error  (Only LedgerId and EntryId are compulsory it seems for stream's messageId rest seem to be optional).